### PR TITLE
Register Filesystem service provider and add disk configuration

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -28,6 +28,7 @@ return [
         Illuminate\Broadcasting\BroadcastServiceProvider::class,
         Illuminate\Bus\BusServiceProvider::class,
         Illuminate\Cache\CacheServiceProvider::class,
+        Illuminate\Filesystem\FilesystemServiceProvider::class,
         Illuminate\Foundation\Providers\ConsoleSupportServiceProvider::class,
         Illuminate\Hashing\HashServiceProvider::class,
         Illuminate\Mail\MailServiceProvider::class,

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -1,0 +1,37 @@
+<?php
+
+return [
+    'default' => env('FILESYSTEM_DISK', 'local'),
+
+    'disks' => [
+        'local' => [
+            'driver' => 'local',
+            'root' => storage_path('app'),
+            'throw' => false,
+        ],
+
+        'public' => [
+            'driver' => 'local',
+            'root' => storage_path('app/public'),
+            'url' => env('APP_URL').'/storage',
+            'visibility' => 'public',
+            'throw' => false,
+        ],
+
+        's3' => [
+            'driver' => 's3',
+            'key' => env('AWS_ACCESS_KEY_ID'),
+            'secret' => env('AWS_SECRET_ACCESS_KEY'),
+            'region' => env('AWS_DEFAULT_REGION'),
+            'bucket' => env('AWS_BUCKET'),
+            'url' => env('AWS_URL'),
+            'endpoint' => env('AWS_ENDPOINT'),
+            'use_path_style_endpoint' => env('AWS_USE_PATH_STYLE_ENDPOINT', false),
+            'throw' => false,
+        ],
+    ],
+
+    'links' => [
+        storage_path('app/public') => public_path('storage'),
+    ],
+];


### PR DESCRIPTION
## Summary
- Register `FilesystemServiceProvider` so the `files` binding is available
- Add default filesystem configuration for local, public, and s3 disks

## Testing
- `php -l config/app.php`
- `php -l config/filesystems.php`
- `php artisan config:clear` *(fails: Failed opening required 'vendor/autoload.php')*
- `php artisan` *(fails: Failed opening required 'vendor/autoload.php')*


------
https://chatgpt.com/codex/tasks/task_e_68b32b9b5564832d9db4dea2aec08fe4