### PR TITLE
Register database service provider to resolve DB binding

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -28,6 +28,7 @@ return [
         Illuminate\Broadcasting\BroadcastServiceProvider::class,
         Illuminate\Bus\BusServiceProvider::class,
         Illuminate\Cache\CacheServiceProvider::class,
+        Illuminate\Database\DatabaseServiceProvider::class,
         Illuminate\Filesystem\FilesystemServiceProvider::class,
         Illuminate\Foundation\Providers\ConsoleSupportServiceProvider::class,
         Illuminate\Hashing\HashServiceProvider::class,


### PR DESCRIPTION
## Summary
- include `Illuminate\Database\DatabaseServiceProvider` in config/app.php so the container binds the `db` service

## Testing
- `php artisan test` *(fails: vendor/autoload.php not found)*
- `composer install` *(fails: curl error 56 connect 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b32cb7c90c832d9010fb77142a5341