### PR TITLE
feat: add public front controller and nginx setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@
 - Composer
 - MySQL
 - MongoDB (PHP 확장 2.1+)
+- Nginx
+- PHP-FPM (PHP 8.2)
 
 ### Steps
 
@@ -45,3 +47,72 @@
    ```bash
    php artisan serve
    ```
+
+## Nginx + PHP-FPM Setup
+
+For production or serving through a web server, configure Nginx to use PHP-FPM.
+
+### Prerequisites
+
+- Nginx
+- PHP-FPM (matching the PHP version, e.g., `php8.2-fpm`)
+
+### Front controller
+
+The application entry point is `public/index.php`:
+
+```php
+<?php
+
+use Illuminate\Contracts\Http\Kernel;
+use Illuminate\Http\Request;
+
+define('LARAVEL_START', microtime(true));
+
+require __DIR__.'/../vendor/autoload.php';
+
+$app = require_once __DIR__.'/../bootstrap/app.php';
+
+$kernel = $app->make(Kernel::class);
+
+$response = $kernel->handle(
+    $request = Request::capture()
+);
+
+$response->send();
+
+$kernel->terminate($request, $response);
+```
+
+### Example Nginx configuration
+
+```
+server {
+    listen 80;
+    server_name example.com;
+    root /path/to/aegis/public;
+
+    index index.php index.html;
+
+    location / {
+        try_files $uri $uri/ /index.php?$query_string;
+    }
+
+    location ~ \.php$ {
+        include snippets/fastcgi-php.conf;
+        fastcgi_pass unix:/var/run/php/php8.2-fpm.sock;
+    }
+
+    location ~ /\.ht {
+        deny all;
+    }
+}
+```
+
+After saving the configuration, restart the services:
+
+```bash
+sudo systemctl restart nginx php8.2-fpm
+```
+
+Ensure the `storage` and `bootstrap/cache` directories are writable by the web server user.

--- a/public/index.php
+++ b/public/index.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Contracts\Http\Kernel;
+use Illuminate\Http\Request;
+
+define('LARAVEL_START', microtime(true));
+
+require __DIR__.'/../vendor/autoload.php';
+
+$app = require_once __DIR__.'/../bootstrap/app.php';
+
+$kernel = $app->make(Kernel::class);
+
+$response = $kernel->handle(
+    $request = Request::capture()
+);
+
+$response->send();
+
+$kernel->terminate($request, $response);
+


### PR DESCRIPTION
## Summary
- document Nginx and PHP-FPM requirements
- add example Nginx configuration and deployment notes
- include a `public/index.php` front controller

## Testing
- `php -l public/index.php`
- `composer validate`


------
https://chatgpt.com/codex/tasks/task_e_68b570d024e8832d8b2651d4659a471f