### PR TITLE
Define web middleware group and superadmin check

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -8,22 +8,35 @@ class Kernel extends HttpKernel
 {
     /**
      * The application's global HTTP middleware stack.
-     *
-     * @var array
      */
-    protected $middleware = [];
+    protected $middleware = [
+        // Add global middleware here if needed
+    ];
 
     /**
      * The application's route middleware groups.
-     *
-     * @var array
      */
-    protected $middlewareGroups = [];
+    protected $middlewareGroups = [
+        'web' => [
+            \Illuminate\Cookie\Middleware\EncryptCookies::class,
+            \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
+            \Illuminate\Session\Middleware\StartSession::class,
+            \Illuminate\View\Middleware\ShareErrorsFromSession::class,
+            \Illuminate\Foundation\Http\Middleware\VerifyCsrfToken::class,
+            \Illuminate\Routing\Middleware\SubstituteBindings::class,
+        ],
+
+        'api' => [
+            \Illuminate\Routing\Middleware\ThrottleRequests::class . ':api',
+            \Illuminate\Routing\Middleware\SubstituteBindings::class,
+        ],
+    ];
 
     /**
      * The application's route middleware.
-     *
-     * @var array
      */
-    protected $routeMiddleware = [];
+    protected $routeMiddleware = [
+        'auth' => \Illuminate\Auth\Middleware\Authenticate::class,
+        'superadmin' => \App\Http\Middleware\EnsureSuperAdmin::class,
+    ];
 }

--- a/app/Http/Middleware/EnsureSuperAdmin.php
+++ b/app/Http/Middleware/EnsureSuperAdmin.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class EnsureSuperAdmin
+{
+    /**
+     * Handle an incoming request.
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $user = $request->user();
+
+        if (!$user || !$user->is_superadmin) {
+            abort(403);
+        }
+
+        return $next($request);
+    }
+}


### PR DESCRIPTION
## Summary
- restore web and api middleware groups in HTTP kernel
- add superadmin authorization middleware

## Testing
- `php -l app/Http/Kernel.php`
- `php -l app/Http/Middleware/EnsureSuperAdmin.php`
- `composer install` *(fails: curl error 56 while downloading https://repo.packagist.org/packages.json)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b57af75754832da9b810ea92060914