### PR TITLE
Add default auth configuration

### DIFF
--- a/config/auth.php
+++ b/config/auth.php
@@ -1,0 +1,40 @@
+<?php
+
+return [
+    'defaults' => [
+        'guard' => 'web',
+        'passwords' => 'users',
+    ],
+
+    'guards' => [
+        'web' => [
+            'driver' => 'session',
+            'provider' => 'users',
+        ],
+
+        'api' => [
+            'driver' => 'token',
+            'provider' => 'users',
+            'hash' => false,
+        ],
+    ],
+
+    'providers' => [
+        'users' => [
+            'driver' => 'eloquent',
+            'model' => App\\Models\\User::class,
+        ],
+    ],
+
+    'passwords' => [
+        'users' => [
+            'provider' => 'users',
+            'table' => 'password_reset_tokens',
+            'expire' => 60,
+            'throttle' => 60,
+        ],
+    ],
+
+    'password_timeout' => 10800,
+];
+


### PR DESCRIPTION
## Summary
- define default web and api guards
- add user provider and password reset settings to config

## Testing
- ⚠️ `composer install` (curl error 56: CONNECT tunnel failed 403)
- ⚠️ `php artisan test` (failed opening required 'vendor/autoload.php')

------
https://chatgpt.com/codex/tasks/task_e_68b58aaa7804832dbf1343ffb76d3d6a