### PR TITLE
Register translation service provider

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -39,6 +39,7 @@ return [
         Illuminate\Pipeline\PipelineServiceProvider::class,
         Illuminate\Queue\QueueServiceProvider::class,
         Illuminate\Session\SessionServiceProvider::class,
+        Illuminate\Translation\TranslationServiceProvider::class,
         Illuminate\Validation\ValidationServiceProvider::class,
         Illuminate\View\ViewServiceProvider::class,
 


### PR DESCRIPTION
## Summary
- register `Illuminate\Translation\TranslationServiceProvider` to restore translator service

## Testing
- `php artisan test` *(fails: Failed opening required '/workspace/aegis/vendor/autoload.php')*
- `composer install` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b595af1134832dbb0ac052d9628902