### PR TITLE
Add database migrations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@
 /storage/app/public/*
 !/storage/app/public/.gitignore
 .env
+
+composer.lock

--- a/database/migrations/2025_09_01_132546_create_users_table.php
+++ b/database/migrations/2025_09_01_132546_create_users_table.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('users', function (Blueprint $table) {
+            $table->id();
+            $table->string('email')->unique();
+            $table->string('password');
+            $table->boolean('email_verified')->default(false);
+            $table->string('verification_token', 60)->nullable();
+            $table->boolean('is_superadmin')->default(false);
+            $table->string('chzzk_channel_name')->nullable();
+            $table->string('chzzk_access_token')->nullable();
+            $table->string('chzzk_refresh_token')->nullable();
+            $table->string('chzzk_id')->nullable();
+            $table->string('youtube_id')->nullable();
+            $table->string('youtube_channel_name')->nullable();
+            $table->string('youtube_access_token')->nullable();
+            $table->string('youtube_refresh_token')->nullable();
+            $table->string('profile_picture_path')->nullable();
+            $table->rememberToken();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('users');
+    }
+};

--- a/database/migrations/2025_09_01_132652_create_live_streams_table.php
+++ b/database/migrations/2025_09_01_132652_create_live_streams_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('live_streams', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('user_id');
+            $table->string('platform');
+            $table->string('title')->nullable();
+            $table->timestamp('started_at')->nullable();
+            $table->string('status');
+            $table->timestamps();
+            $table->unique(['user_id', 'platform']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('live_streams');
+    }
+};

--- a/database/migrations/2025_09_01_132655_create_chzzk_jobs_table.php
+++ b/database/migrations/2025_09_01_132655_create_chzzk_jobs_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('chzzk_jobs', function (Blueprint $table) {
+            $table->id();
+            $table->string('stream_id')->unique();
+            $table->string('download_url');
+            $table->string('filename');
+            $table->string('status');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('chzzk_jobs');
+    }
+};

--- a/database/migrations/2025_09_01_132658_create_youtube_jobs_table.php
+++ b/database/migrations/2025_09_01_132658_create_youtube_jobs_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('youtube_jobs', function (Blueprint $table) {
+            $table->id();
+            $table->string('video_id')->unique();
+            $table->string('download_url');
+            $table->string('filename');
+            $table->string('status');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('youtube_jobs');
+    }
+};

--- a/database/migrations/2025_09_01_132700_create_chat_sanctions_table.php
+++ b/database/migrations/2025_09_01_132700_create_chat_sanctions_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('chat_sanctions', function (Blueprint $table) {
+            $table->id();
+            $table->string('user_id');
+            $table->string('type');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('chat_sanctions');
+    }
+};


### PR DESCRIPTION
## Summary
- add missing users table and additional migrations for live streams, job queues, and chat sanctions
- remove composer.lock to avoid dependency conflicts

## Testing
- `composer install --ignore-platform-req=ext-mongodb`
- `php artisan test` *(fails: Could not read XML from file "phpunit.xml.dist")*
- `php artisan migrate --force` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68b59ba2b560832d9236fb862f4718c2