### PR TITLE
Add Guzzle dependency for HTTP client

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,10 +4,11 @@
   "description": "Streaming management and chat moderation app",
   "require": {
     "php": "^8.2",
+    "guzzlehttp/guzzle": "^7.10",
     "laravel/framework": "^10.0",
-    "mongodb/mongodb": "^2.1",
     "laravel/sanctum": "^3.2",
-    "laravel/tinker": "^2.8"
+    "laravel/tinker": "^2.8",
+    "mongodb/mongodb": "^2.1"
   },
   "require-dev": {
     "fakerphp/faker": "^1.9.1",


### PR DESCRIPTION
## Summary
- Include `guzzlehttp/guzzle` in project dependencies to enable Laravel HTTP client operations.

## Testing
- `php artisan test` *(fails: Could not read XML from file "/workspace/aegis/phpunit.xml.dist")*

------
https://chatgpt.com/codex/tasks/task_e_68b5c6aef59c832dabb6a9f8af3faebe