### PR TITLE
Add OAuth state to Chzzk login

### DIFF
--- a/app/Http/Controllers/OAuth/ChzzkController.php
+++ b/app/Http/Controllers/OAuth/ChzzkController.php
@@ -2,38 +2,49 @@
 
 namespace App\Http\Controllers\OAuth;
 
-use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Http;
-use Illuminate\Support\Facades\Auth;
 use App\Http\Controllers\Controller;
 use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Session;
+use Illuminate\Support\Str;
 
 class ChzzkController extends Controller
 {
     public function redirect()
     {
+        $state = Str::random(40);
+        Session::put('chzzkOauthState', $state);
+
         $query = http_build_query([
-            'response_type' => 'code',
-            'client_id' => config('services.chzzk.client_id'),
-            'redirect_uri' => route('oauth.chzzk.callback'),
+            'responseType' => 'code',
+            'clientId' => config('services.chzzk.client_id'),
+            'redirectUri' => route('oauth.chzzk.callback'),
             'scope' => 'profile channel:read channel:chat',
+            'state' => $state,
         ]);
+
         return redirect(config('services.chzzk.auth_url').'?'.$query);
     }
 
     public function callback(Request $request)
     {
+        if ($request->query('state') !== Session::pull('chzzkOauthState')) {
+            abort(403, 'Invalid OAuth state');
+        }
+
         $code = $request->query('code');
         $tokenResponse = Http::asForm()->post(config('services.chzzk.token_url'), [
-            'grant_type' => 'authorization_code',
-            'client_id' => config('services.chzzk.client_id'),
-            'client_secret' => config('services.chzzk.client_secret'),
+            'grantType' => 'authorization_code',
+            'clientId' => config('services.chzzk.client_id'),
+            'clientSecret' => config('services.chzzk.client_secret'),
             'code' => $code,
-            'redirect_uri' => route('oauth.chzzk.callback'),
+            'redirectUri' => route('oauth.chzzk.callback'),
         ]);
         $tokens = $tokenResponse->json();
 
-        $profile = Http::withToken($tokens['access_token'])
+        $profile = Http::withToken($tokens['accessToken'])
             ->get(config('services.chzzk.api_url').'/users/me')
             ->json();
 
@@ -41,12 +52,13 @@ class ChzzkController extends Controller
             ['chzzk_id' => $profile['id']],
             ['email' => $profile['email'] ?? null]
         );
-        $user->chzzk_channel_name = $profile['channel_name'] ?? null;
-        $user->chzzk_access_token = $tokens['access_token'];
-        $user->chzzk_refresh_token = $tokens['refresh_token'];
+        $user->chzzk_channel_name = $profile['channelName'] ?? null;
+        $user->chzzk_access_token = $tokens['accessToken'];
+        $user->chzzk_refresh_token = $tokens['refreshToken'] ?? null;
         $user->save();
 
         Auth::login($user);
+
         return redirect('/');
     }
 }


### PR DESCRIPTION
## Summary
- add CSRF `state` parameter to Chzzk OAuth flow
- validate returned `state` before exchanging code for tokens
- handle token response with camelCase fields (`accessToken`, `refreshToken`) and use `channelName` in profile

## Testing
- `php vendor/bin/pint app/Http/Controllers/OAuth/ChzzkController.php`
- `php artisan test` *(fails: Could not read XML from file "/workspace/aegis/phpunit.xml.dist")*


------
https://chatgpt.com/codex/tasks/task_e_68b5b5601cd0832d91c3dacb04a99339