### PR TITLE
Set default email and password for Chzzk OAuth users

### DIFF
--- a/app/Http/Controllers/OAuth/ChzzkController.php
+++ b/app/Http/Controllers/OAuth/ChzzkController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Models\User;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Session;
 use Illuminate\Support\Str;
@@ -50,7 +51,10 @@ class ChzzkController extends Controller
 
         $user = User::firstOrCreate(
             ['chzzk_id' => $profile['id']],
-            ['email' => $profile['email'] ?? null]
+            [
+                'email' => $profile['email'] ?? Str::uuid().'@example.com',
+                'password' => Hash::make(Str::random(32)),
+            ]
         );
         $user->chzzk_channel_name = $profile['channelName'] ?? null;
         $user->chzzk_access_token = $tokens['accessToken'];


### PR DESCRIPTION
## Summary
- Assign a random hashed password when creating users via Chzzk OAuth to satisfy DB constraints
- Generate a placeholder email when Chzzk profile lacks one

## Testing
- `php artisan test` *(fails: Could not read XML from file "/workspace/aegis/phpunit.xml.dist")*

------
https://chatgpt.com/codex/tasks/task_e_68b5d45f03ac832d9109dce48c56c4ef